### PR TITLE
Extend LanServers to all addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The only feature is listing the server as a LanServer in the Multiplayer-Menu of
 The same as the Minecraft Client when you open your world to LAN.  
 
 Every 1.5 seconds, the plugin sends a special message with the server port and MOTD to `224.0.2.60` on port 4445 from every interface.
-`224.0.2.60` is a _multicast_ addresse which means that everyone in you local network that wants
+`224.0.2.60` is a _multicast_ address which means that everyone in you local network that wants
 to get messages sent to this address will get them, for example, like your Minecraft Client when you're in the Multiplayer Menu.
 
 That's all it does so compatibility should not break when updating to newer Server versions.

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ The only feature is listing the server as a LanServer in the Multiplayer-Menu of
 
 The same as the Minecraft Client when you open your world to LAN.  
 
-Every 1.5 seconds, the plugin sends a special message with the server port and MOTD to `224.0.2.60` — or `ff75:230::60` for IPv6 — on port 4445 from every interface.
-`224.0.2.60` and `ff75:230::60` are _multicast_ addresses which means that everyone in you local network that wants
-to get messages sent these addresses will get them, for example, like your Minecraft Client when you're in the Multiplayer Menu.
+Every 1.5 seconds, the plugin sends a special message with the server port and MOTD to `224.0.2.60` on port 4445 from every interface.
+`224.0.2.60` is a _multicast_ addresse which means that everyone in you local network that wants
+to get messages sent to this address will get them, for example, like your Minecraft Client when you're in the Multiplayer Menu.
 
 That's all it does so compatibility should not break when updating to newer Server versions.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,20 @@
 # LanServers
 
-This is a small plugin written in Kotlin that runs on all major Minecraft Servers.  
+This is a small plugin that runs on all major Minecraft Servers.  
 The only feature is listing the server as a LanServer in the Multiplayer-Menu of Minecraft.  
 
 # Supported Servers
+
 - Bukkit/Spigot/Paper 1.8+
 - Bungeecord 1.16+
 - Velocity 3.0.1+
 
 # What does it do exactly?
+
 The same as the Minecraft Client when you open your world to LAN.  
-It sends every 1.5 seconds a special message with the server port and MOTD to `224.0.2.60` on port 4445.
-`224.0.2.60` is a Multicast Address which means that everyone in you local network that wants
-to get messages sent to `224.0.2.60` will get them like your Minecraft Client when you're in the Multiplayer Menu.
+
+Every 1.5 seconds, the plugin sends a special message with the server port and MOTD to `224.0.2.60` — or `ff75:230::60` for IPv6 — on port 4445 from every interface.
+`224.0.2.60` and `ff75:230::60` are _multicast_ addresses which means that everyone in you local network that wants
+to get messages sent these addresses will get them, for example, like your Minecraft Client when you're in the Multiplayer Menu.
 
 That's all it does so compatibility should not break when updating to newer Server versions.

--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -6,8 +6,6 @@ This is a new version of LanServers.
 
 To use it you need at least Java 8.
 
-It supports IPv4 and IPv6
-
 # Compatibility
 
 This plugin is one jar that runs on all major servers.

--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -6,7 +6,10 @@ This is a new version of LanServers.
 
 To use it you need at least Java 8.
 
+It supports IPv4 and IPv6
+
 # Compatibility
+
 This plugin is one jar that runs on all major servers.
 
 - Bukkit/Spigot/Paper 1.8+

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>lanservers</artifactId>
     <groupId>net.redstonecraft</groupId>
-    <version>2.0.0</version>
+    <version>1.2.0</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>lanservers</artifactId>
     <groupId>net.redstonecraft</groupId>
-    <version>1.1.1</version>
+    <version>2.0.0</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/src/main/java/net/redstonecraft/lanservers/LanServers.java
+++ b/src/main/java/net/redstonecraft/lanservers/LanServers.java
@@ -18,14 +18,14 @@ public class LanServers {
     private final List<MulticastSocket> sources = LanServers.getSourceSockets();
     private final ILanServersPlugin plugin;
 
-    public LanServers(ILanServersPlugin plugin) throws IOException {
+    public LanServers(ILanServersPlugin plugin) throws UnknownHostException, SocketException {
         this.plugin = plugin;
+    }
+
+    public void enable() throws IOException {
         for (MulticastSocket socket : sources) {
             socket.joinGroup(multicastAddress);
         }
-    }
-
-    public void enable() {
         timer.schedule(new TimerTask() {
             @Override
             public void run() {

--- a/src/main/java/net/redstonecraft/lanservers/LanServers.java
+++ b/src/main/java/net/redstonecraft/lanservers/LanServers.java
@@ -66,6 +66,7 @@ public class LanServers {
                             // get actual address
                             // make socket, ignore errors
                             .map(ifaddr -> ifaddr.getAddress())
+                            .filter(inaddr -> (inaddr instanceof Inet4Address))
                             .map(inaddr -> new InetSocketAddress(inaddr, multicastPort))
                             .map(insaddr -> {
                                 try {

--- a/src/main/java/net/redstonecraft/lanservers/LanServers.java
+++ b/src/main/java/net/redstonecraft/lanservers/LanServers.java
@@ -65,12 +65,15 @@ public class LanServers {
                             .filter(inaddr -> (inaddr instanceof Inet4Address))
                             .map(inaddr -> new InetSocketAddress(inaddr, multicastPort))
                             .map(insaddr -> {
+                                // Only interested in interfaces/addresses that
+                                // can do multicast, so ignore errors ...
                                 try {
                                     return new MulticastSocket(insaddr);
                                 } catch (IOException e) {
                                     return null;
                                 }
                             }))
+                    // ... and filter out null afterwards
                     .filter(Objects::nonNull)
                     .collect(Collectors.toList());
         } catch (SocketException e) {

--- a/src/main/java/net/redstonecraft/lanservers/LanServers.java
+++ b/src/main/java/net/redstonecraft/lanservers/LanServers.java
@@ -51,9 +51,7 @@ public class LanServers {
 
     private static List<MulticastSocket> getSourceSockets() {
         try {
-            // Take all network interfaces
             return Collections.list(NetworkInterface.getNetworkInterfaces()).stream()
-                    // keep all relevant (not localhost, up, can multicast)
                     .filter(iface -> {
                         try {
                             return iface.supportsMulticast() && iface.isUp() && !iface.isLoopback();
@@ -63,8 +61,6 @@ public class LanServers {
                     })
                     // interface can have multiple addresses, make a loooong list
                     .flatMap(iface -> iface.getInterfaceAddresses().stream()
-                            // get actual address
-                            // make socket, ignore errors
                             .map(ifaddr -> ifaddr.getAddress())
                             .filter(inaddr -> (inaddr instanceof Inet4Address))
                             .map(inaddr -> new InetSocketAddress(inaddr, multicastPort))

--- a/src/main/java/net/redstonecraft/lanservers/LanServers.java
+++ b/src/main/java/net/redstonecraft/lanservers/LanServers.java
@@ -3,19 +3,31 @@ package net.redstonecraft.lanservers;
 import java.io.IOException;
 import java.net.*;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.stream.Collectors;
 
 public class LanServers {
 
     private final Timer timer = new Timer();
-    private final InetAddress multicastAddress = InetAddress.getByName("224.0.2.60");
-    private final int multicastPort = 4445;
-    private final DatagramSocket socket = new DatagramSocket();
+    private final Inet4Address multicastAddress4 = (Inet4Address) InetAddress.getByName("224.0.2.60");
+    private final Inet6Address multicastAddress6 = (Inet6Address) InetAddress.getByName("ff75:230::60");
+    private final static int multicastPort = 4445;
+    private final List<MulticastSocket> sources4 = LanServers.getSourceSockets(false);
+    private final List<MulticastSocket> sources6 = LanServers.getSourceSockets(true);
     private final ILanServersPlugin plugin;
 
-    public LanServers(ILanServersPlugin plugin) throws UnknownHostException, SocketException {
+    public LanServers(ILanServersPlugin plugin) throws IOException {
         this.plugin = plugin;
+        for (MulticastSocket socket : sources4) {
+            socket.joinGroup(multicastAddress4);
+        }
+        for (MulticastSocket socket : sources6) {
+            socket.joinGroup(multicastAddress6);
+        }
     }
 
     public void enable() {
@@ -23,11 +35,21 @@ public class LanServers {
             @Override
             public void run() {
                 byte[] data = ("[MOTD]" + plugin.getMotd() + "[/MOTD][AD]" + plugin.getPort() + "[/AD]").getBytes(StandardCharsets.UTF_8);
-                DatagramPacket packet = new DatagramPacket(data, data.length, multicastAddress, multicastPort);
-                try {
-                    socket.send(packet);
-                } catch (IOException e) {
-                    e.printStackTrace();
+                DatagramPacket packet = new DatagramPacket(data, data.length, multicastAddress4, multicastPort);
+                for (MulticastSocket socket :  sources4) {
+                    try {
+                        socket.send(packet);
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                }
+                packet = new DatagramPacket(data, data.length, multicastAddress6, multicastPort);
+                for (MulticastSocket socket :  sources6) {
+                    try {
+                        socket.send(packet);
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
                 }
             }
         }, 0, 1500);
@@ -35,7 +57,47 @@ public class LanServers {
 
     public void disable() {
         timer.cancel();
-        socket.close();
+        for (MulticastSocket socket :  sources4) {
+            socket.close();
+        }
+        for (MulticastSocket socket :  sources6) {
+            socket.close();
+        }
+
     }
 
+    private static List<MulticastSocket> getSourceSockets(boolean doIPv6) {
+        try {
+            // Take all network interfaces
+            return Collections.list(NetworkInterface.getNetworkInterfaces()).stream()
+                    // keep all relevant (not localhost, up, can multicast)
+                    .filter(iface -> {
+                        try {
+                            return iface.supportsMulticast() && iface.isUp() && !iface.isLoopback();
+                        } catch (SocketException e) {
+                            return false;
+                        }
+                    })
+                    // interface can have multiple addresses, make a loooong list
+                    .flatMap(iface -> iface.getInterfaceAddresses().stream()
+                            // get actual address
+                            // select ipv6 if desired
+                            // make socket, ignore errors
+                            .map(ifaddr -> ifaddr.getAddress())
+                            .filter(inaddr -> (inaddr instanceof Inet6Address) == doIPv6)
+                            .map(inaddr -> new InetSocketAddress(inaddr, multicastPort))
+                            .map(insaddr -> {
+                                try {
+                                    return new MulticastSocket(insaddr);
+                                } catch (IOException e) {
+                                    return null;
+                                }
+                            }))
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList());
+        } catch (SocketException e) {
+            e.printStackTrace();
+            return Collections.emptyList();
+        }
+    }
 }

--- a/src/main/java/net/redstonecraft/lanservers/LanServers.java
+++ b/src/main/java/net/redstonecraft/lanservers/LanServers.java
@@ -13,20 +13,15 @@ import java.util.stream.Collectors;
 public class LanServers {
 
     private final Timer timer = new Timer();
-    private final Inet4Address multicastAddress4 = (Inet4Address) InetAddress.getByName("224.0.2.60");
-    private final Inet6Address multicastAddress6 = (Inet6Address) InetAddress.getByName("ff75:230::60");
+    private final Inet4Address multicastAddress = (Inet4Address) InetAddress.getByName("224.0.2.60");
     private final static int multicastPort = 4445;
-    private final List<MulticastSocket> sources4 = LanServers.getSourceSockets(false);
-    private final List<MulticastSocket> sources6 = LanServers.getSourceSockets(true);
+    private final List<MulticastSocket> sources = LanServers.getSourceSockets();
     private final ILanServersPlugin plugin;
 
     public LanServers(ILanServersPlugin plugin) throws IOException {
         this.plugin = plugin;
-        for (MulticastSocket socket : sources4) {
-            socket.joinGroup(multicastAddress4);
-        }
-        for (MulticastSocket socket : sources6) {
-            socket.joinGroup(multicastAddress6);
+        for (MulticastSocket socket : sources) {
+            socket.joinGroup(multicastAddress);
         }
     }
 
@@ -35,16 +30,8 @@ public class LanServers {
             @Override
             public void run() {
                 byte[] data = ("[MOTD]" + plugin.getMotd() + "[/MOTD][AD]" + plugin.getPort() + "[/AD]").getBytes(StandardCharsets.UTF_8);
-                DatagramPacket packet = new DatagramPacket(data, data.length, multicastAddress4, multicastPort);
-                for (MulticastSocket socket :  sources4) {
-                    try {
-                        socket.send(packet);
-                    } catch (IOException e) {
-                        e.printStackTrace();
-                    }
-                }
-                packet = new DatagramPacket(data, data.length, multicastAddress6, multicastPort);
-                for (MulticastSocket socket :  sources6) {
+                DatagramPacket packet = new DatagramPacket(data, data.length, multicastAddress, multicastPort);
+                for (MulticastSocket socket :  sources) {
                     try {
                         socket.send(packet);
                     } catch (IOException e) {
@@ -57,16 +44,12 @@ public class LanServers {
 
     public void disable() {
         timer.cancel();
-        for (MulticastSocket socket :  sources4) {
+        for (MulticastSocket socket :  sources) {
             socket.close();
         }
-        for (MulticastSocket socket :  sources6) {
-            socket.close();
-        }
-
     }
 
-    private static List<MulticastSocket> getSourceSockets(boolean doIPv6) {
+    private static List<MulticastSocket> getSourceSockets() {
         try {
             // Take all network interfaces
             return Collections.list(NetworkInterface.getNetworkInterfaces()).stream()
@@ -81,10 +64,8 @@ public class LanServers {
                     // interface can have multiple addresses, make a loooong list
                     .flatMap(iface -> iface.getInterfaceAddresses().stream()
                             // get actual address
-                            // select ipv6 if desired
                             // make socket, ignore errors
                             .map(ifaddr -> ifaddr.getAddress())
-                            .filter(inaddr -> (inaddr instanceof Inet6Address) == doIPv6)
                             .map(inaddr -> new InetSocketAddress(inaddr, multicastPort))
                             .map(insaddr -> {
                                 try {

--- a/src/main/java/net/redstonecraft/lanservers/LanServersBukkit.java
+++ b/src/main/java/net/redstonecraft/lanservers/LanServersBukkit.java
@@ -2,8 +2,8 @@ package net.redstonecraft.lanservers;
 
 import org.bukkit.plugin.java.JavaPlugin;
 
-import java.net.SocketException;
-import java.net.UnknownHostException;
+import java.io.IOException;
+
 
 public class LanServersBukkit extends JavaPlugin implements ILanServersPlugin {
 
@@ -14,7 +14,7 @@ public class LanServersBukkit extends JavaPlugin implements ILanServersPlugin {
         if (lanServers == null) {
             try {
                 lanServers = new LanServers(this);
-            } catch (UnknownHostException | SocketException e) {
+            } catch (IOException e) {
                 e.printStackTrace();
             }
         }

--- a/src/main/java/net/redstonecraft/lanservers/LanServersBukkit.java
+++ b/src/main/java/net/redstonecraft/lanservers/LanServersBukkit.java
@@ -13,11 +13,11 @@ public class LanServersBukkit extends JavaPlugin implements ILanServersPlugin {
         if (lanServers == null) {
             try {
                 lanServers = new LanServers(this);
+                lanServers.enable();
             } catch (IOException e) {
                 e.printStackTrace();
             }
         }
-        lanServers.enable();
     }
 
     @Override

--- a/src/main/java/net/redstonecraft/lanservers/LanServersBukkit.java
+++ b/src/main/java/net/redstonecraft/lanservers/LanServersBukkit.java
@@ -4,7 +4,6 @@ import org.bukkit.plugin.java.JavaPlugin;
 
 import java.io.IOException;
 
-
 public class LanServersBukkit extends JavaPlugin implements ILanServersPlugin {
 
     private LanServers lanServers = null;

--- a/src/main/java/net/redstonecraft/lanservers/LanServersBungee.java
+++ b/src/main/java/net/redstonecraft/lanservers/LanServersBungee.java
@@ -15,11 +15,11 @@ public class LanServersBungee extends Plugin implements ILanServersPlugin {
         if (lanServers == null) {
             try {
                 lanServers = new LanServers(this);
+                lanServers.enable();
             } catch (IOException e) {
                 e.printStackTrace();
             }
         }
-        lanServers.enable();
     }
 
     @Override

--- a/src/main/java/net/redstonecraft/lanservers/LanServersBungee.java
+++ b/src/main/java/net/redstonecraft/lanservers/LanServersBungee.java
@@ -3,8 +3,7 @@ package net.redstonecraft.lanservers;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.plugin.Plugin;
 
-import java.net.SocketException;
-import java.net.UnknownHostException;
+import java.io.IOException;
 import java.util.Objects;
 
 public class LanServersBungee extends Plugin implements ILanServersPlugin {
@@ -16,7 +15,7 @@ public class LanServersBungee extends Plugin implements ILanServersPlugin {
         if (lanServers == null) {
             try {
                 lanServers = new LanServers(this);
-            } catch (UnknownHostException | SocketException e) {
+            } catch (IOException e) {
                 e.printStackTrace();
             }
         }

--- a/src/main/java/net/redstonecraft/lanservers/LanServersVelocity.java
+++ b/src/main/java/net/redstonecraft/lanservers/LanServersVelocity.java
@@ -36,11 +36,11 @@ public class LanServersVelocity implements ILanServersPlugin {
         if (lanServers == null) {
             try {
                 lanServers = new LanServers(this);
+                lanServers.enable();
             } catch (IOException e) {
                 e.printStackTrace();
             }
         }
-        lanServers.enable();
     }
 
     @Subscribe

--- a/src/main/java/net/redstonecraft/lanservers/LanServersVelocity.java
+++ b/src/main/java/net/redstonecraft/lanservers/LanServersVelocity.java
@@ -9,13 +9,13 @@ import com.velocitypowered.api.proxy.ProxyServer;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.slf4j.Logger;
 
-import java.net.SocketException;
-import java.net.UnknownHostException;
+import java.io.IOException;
+
 
 @Plugin(
     id = "lanservers",
     name = "LanServers",
-    version = "1.1.0",
+    version = "2.0.0",
     description = "Lists the Server on the Multiplayer list as LanServer if on the same network.",
     url = "https://github.com/Redstonecrafter0/LanServers",
     authors = {
@@ -37,7 +37,7 @@ public class LanServersVelocity implements ILanServersPlugin {
         if (lanServers == null) {
             try {
                 lanServers = new LanServers(this);
-            } catch (UnknownHostException | SocketException e) {
+            } catch (IOException e) {
                 e.printStackTrace();
             }
         }

--- a/src/main/java/net/redstonecraft/lanservers/LanServersVelocity.java
+++ b/src/main/java/net/redstonecraft/lanservers/LanServersVelocity.java
@@ -11,11 +11,10 @@ import org.slf4j.Logger;
 
 import java.io.IOException;
 
-
 @Plugin(
     id = "lanservers",
     name = "LanServers",
-    version = "2.0.0",
+    version = "1.2.0",
     description = "Lists the Server on the Multiplayer list as LanServer if on the same network.",
     url = "https://github.com/Redstonecrafter0/LanServers",
     authors = {


### PR DESCRIPTION
Adds ways to send multicast packages (a) for IPv6 addresses and (b) for all local interfaces.

As it happens, "just" sending a multicast packge will, by default make it's "source" (almost always) the primary IP of the machine. But if the server is listening on multiple (or even all) interfaces, not eveyone will get the memo. So we iterate all local interfaces (that can do multicast and are actually up, but ignore localhost, because what's the point?) and send messages _from_ these addresses. This is a bit involved due to how interfaces/addresses/sockets work in Java.